### PR TITLE
Update ApplySegmentGlobals to call $next

### DIFF
--- a/src/Middleware/ApplySegmentGlobals.php
+++ b/src/Middleware/ApplySegmentGlobals.php
@@ -24,6 +24,8 @@ class ApplySegmentGlobals
          * Build some nice default context based on the current request.
          */
         Segment::setGlobalContext($this->getContext($request));
+        
+        return $next($request);
     }
 
     private function getContext(Request $request): array


### PR DESCRIPTION
From the [docs](https://laravel.com/docs/9.x/middleware):
> To pass the request deeper into the application (allowing the middleware to "pass"), you should call the $next callback with the $request.

The middleware currently does not call `$next` which makes it break with multiple middleware.