### PR TITLE
Support context on a per-event basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,35 @@ Segment::setGlobalContext([
 ]);
 ```
 
+### Setting context on a per event basis
+
+You can also set context on a per event basis. This will merge the context you provide with the global context.
+
+```php
+use SlashEquip\LaravelSegment\Facades\Segment;
+
+// Identify user with context
+Segment::forUser($user)->identify([
+    'name' => 'John Doe',
+], [
+    'page' => [
+        'path' => '/signup',
+        'referrer' => 'https://producthunt.com',
+    ],
+]);
+
+// Track example event with context
+Segment::forUser($user)->track('User Signed Up', [
+    'source' => 'Product Hunt',
+], [
+    'page' => [
+        'path' => '/signup',
+        'referrer' => 'https://producthunt.com',
+    ],
+]);
+```
+
+
 ### Here have some convenience
 
 Laravel Segment ships with a middleware that you can apply in your HTTP Kernal that will handle

--- a/src/PendingUserSegment.php
+++ b/src/PendingUserSegment.php
@@ -16,17 +16,22 @@ class PendingUserSegment
         $this->user = $user;
     }
 
-    public function track(string $event, ?array $eventData = null): void
+    public function track(string $event, ?array $eventData = null, ?array $context = null): void
     {
         $this->service->push(
-            new SimpleSegmentEvent($this->user, $event, $eventData)
+            new SimpleSegmentEvent(
+                $this->user,
+                $event,
+                $eventData,
+                $context
+            )
         );
     }
 
-    public function identify(?array $identifyData = null): void
+    public function identify(?array $identifyData = null, ?array $context = null): void
     {
         $this->service->push(
-            new SimpleSegmentIdentify($this->user, $identifyData)
+            new SimpleSegmentIdentify($this->user, $identifyData, $context)
         );
     }
 }

--- a/src/SegmentService.php
+++ b/src/SegmentService.php
@@ -35,17 +35,17 @@ class SegmentService
         $this->globalContext = $globalContext;
     }
 
-    public function track(string $event, ?array $eventData = null): void
+    public function track(string $event, ?array $eventData = null, ?array $context = null): void
     {
         $this->push(
-            new SimpleSegmentEvent($this->globalUser, $event, $eventData)
+            new SimpleSegmentEvent($this->globalUser, $event, $eventData, $context)
         );
     }
 
-    public function identify(?array $identifyData = null): void
+    public function identify(?array $identifyData = null, ?array $context = null): void
     {
         $this->push(
-            new SimpleSegmentIdentify($this->globalUser, $identifyData)
+            new SimpleSegmentIdentify($this->globalUser, $identifyData, $context)
         );
     }
 
@@ -120,6 +120,11 @@ class SegmentService
         // If it's a tracking call we need an event name!
         if ($payload->getType()->equals(SegmentPayloadType::TRACK())) {
             $data['event'] = $payload->getEvent();
+        }
+
+        // Add individual context. Global context is merged onto it.
+        if (! empty($payload->getContext())) {
+            $data['context'] = $payload->getContext();
         }
 
         return $data;

--- a/src/SimpleSegmentEvent.php
+++ b/src/SimpleSegmentEvent.php
@@ -12,7 +12,8 @@ class SimpleSegmentEvent implements CanBeSentToSegment
     public function __construct(
         private CanBeIdentifiedForSegment $user,
         private string $event,
-        private ?array $eventData
+        private ?array $eventData,
+        private ?array $context = null
     ) {
     }
 
@@ -21,7 +22,8 @@ class SimpleSegmentEvent implements CanBeSentToSegment
         $payload = new SegmentPayload(
             $this->user,
             SegmentPayloadType::TRACK(),
-            $this->eventData
+            $this->eventData,
+            $this->context
         );
 
         $payload->setEvent($this->event);

--- a/src/SimpleSegmentIdentify.php
+++ b/src/SimpleSegmentIdentify.php
@@ -11,7 +11,8 @@ class SimpleSegmentIdentify implements CanBeSentToSegment
 {
     public function __construct(
         private CanBeIdentifiedForSegment $user,
-        private ?array $identifyData = null
+        private ?array $identifyData = null,
+        private ?array $context = null
     ) {
     }
 
@@ -20,7 +21,8 @@ class SimpleSegmentIdentify implements CanBeSentToSegment
         return new SegmentPayload(
             $this->user,
             SegmentPayloadType::IDENTIFY(),
-            $this->identifyData
+            $this->identifyData,
+            $this->context
         );
     }
 }

--- a/src/ValueObjects/SegmentPayload.php
+++ b/src/ValueObjects/SegmentPayload.php
@@ -19,7 +19,8 @@ class SegmentPayload
     public function __construct(
         protected CanBeIdentifiedForSegment $user,
         protected SegmentPayloadType $type,
-        protected ?array $data
+        protected ?array $data,
+        protected ?array $context = null
     ) {
     }
 
@@ -36,6 +37,11 @@ class SegmentPayload
     public function getData(): ?array
     {
         return $this->data;
+    }
+
+    public function getContext(): ?array
+    {
+        return $this->context;
     }
 
     public function getEvent(): string

--- a/tests/Unit/SegmentServiceTest.php
+++ b/tests/Unit/SegmentServiceTest.php
@@ -36,6 +36,10 @@ it('can track a user using the track method with global user and context', funct
     // When we call the track method
     Segment::track('Something Happened', [
         'name' => 'special',
+    ], [
+        'page' => [
+            'title' => 'Home',
+        ]
     ]);
 
     // Then we have made the calls to Segment
@@ -53,6 +57,11 @@ it('can track a user using the track method with global user and context', funct
                     "name" => "special",
                 ],
                 "event" => "Something Happened",
+                "context" => [
+                    "page" => [
+                        "title" => "Home",
+                    ]
+                ]
             ]);
     });
 });
@@ -81,6 +90,10 @@ it('can identify a user using the identify method with global user and context',
     // When we call the track method
     Segment::identify([
         "has_confirmed_something" => true,
+    ], [
+        'page' => [
+            'title' => 'Home',
+        ]
     ]);
 
     // Then we have made the calls to Segment
@@ -97,6 +110,11 @@ it('can identify a user using the identify method with global user and context',
                 "traits" => [
                     "has_confirmed_something" => true,
                 ],
+                "context" => [
+                    "page" => [
+                        "title" => "Home",
+                    ]
+                ]
             ]);
     });
 });
@@ -141,6 +159,10 @@ it('can track a user using the track method for a given user', function () {
     // When we call the track method
     Segment::forUser($user)->track('Something Happened', [
         'name' => 'special',
+    ], [
+        'page' => [
+            'title' => 'Home',
+        ]
     ]);
 
     // Then we have made the calls to Segment
@@ -158,6 +180,11 @@ it('can track a user using the track method for a given user', function () {
                     "name" => "special",
                 ],
                 "event" => "Something Happened",
+                "context" => [
+                    "page" => [
+                        "title" => "Home",
+                    ]
+                ]
             ]);
     });
 });
@@ -178,6 +205,10 @@ it('can identify a user using the identify method for a given user', function ()
     // When we call the track method
     Segment::forUser($user)->identify([
         "has_confirmed_something" => true,
+    ], [
+        'page' => [
+            'title' => 'Home',
+        ]
     ]);
 
     // Then we have made the calls to Segment
@@ -194,6 +225,11 @@ it('can identify a user using the identify method for a given user', function ()
                 "traits" => [
                     "has_confirmed_something" => true,
                 ],
+                "context" => [
+                    "page" => [
+                        "title" => "Home",
+                    ]
+                ]
             ]);
     });
 });


### PR DESCRIPTION
The batch endpoint allows individual context, per https://segment.com/docs/connections/sources/catalog/libraries/server/http-api/#batch

> context Object, optional	The same as Context for other calls, but it will be merged with any context inside each of the items in the batch.

This updates the track and identify methods to take in an optional context array, which carries through to the final API call.

It's useful to be able to pass in page context or anything that may change per event.