### PR TITLE
Remove timezone to avoid timestamp in the future

### DIFF
--- a/src/ValueObjects/SegmentPayload.php
+++ b/src/ValueObjects/SegmentPayload.php
@@ -22,7 +22,6 @@ class SegmentPayload
         DateTime $timestamp = null
     ) {
         $this->timestamp = $timestamp ?: new DateTime();
-        $this->timestamp->setTimezone(new DateTimeZone('UTC'));
     }
 
     public function getDataKey(): string


### PR DESCRIPTION
I use a different timezone than UTC in Laravel (UTC+2), which makes the Segment implementation fail upon transfer to destinations because of "dates in the future" due to timezone confusion.

As DateTime automatically has UTC as default Timezone, removing this line of code should use the default Timezone of the Laravel project.