### PR TITLE
Add now methods to interface and Fake

### DIFF
--- a/src/Contracts/SegmentServiceContract.php
+++ b/src/Contracts/SegmentServiceContract.php
@@ -19,9 +19,20 @@ interface SegmentServiceContract
     public function track(string $event, ?array $eventData = null): void;
 
     /**
+     * @param  array<string, mixed>  $eventData
+     */
+    public function trackNow(string $event, ?array $eventData = null): void;
+
+    /**
      * @param  array<string, mixed>  $identifyData
      */
     public function identify(?array $identifyData = null): void;
+
+    /**
+     * @param  array<string, mixed>  $identifyData
+     */
+    public function identifyNow(?array $identifyData = null): void;
+
 
     public function forUser(CanBeIdentifiedForSegment $user): PendingUserSegment;
 

--- a/src/Facades/Fakes/SegmentFake.php
+++ b/src/Facades/Fakes/SegmentFake.php
@@ -47,9 +47,25 @@ class SegmentFake implements SegmentServiceContract
     }
 
     /**
+     * @param  array<string, mixed>  $identifyData
+     */
+    public function identifyNow(?array $identifyData = []): void
+    {
+        $this->identities[] = new SimpleSegmentIdentify($this->user, $identifyData);
+    }
+
+    /**
      * @param  array<string, mixed>  $eventData
      */
     public function track(string $event, ?array $eventData = null): void
+    {
+        $this->events[] = new SimpleSegmentEvent($this->user, $event, $eventData);
+    }
+
+    /**
+     * @param  array<string, mixed>  $eventData
+     */
+    public function trackNow(string $event, ?array $eventData = null): void
     {
         $this->events[] = new SimpleSegmentEvent($this->user, $event, $eventData);
     }

--- a/src/Facades/Segment.php
+++ b/src/Facades/Segment.php
@@ -2,6 +2,7 @@
 
 namespace SlashEquip\LaravelSegment\Facades;
 
+use Closure;
 use Illuminate\Support\Facades\Facade;
 use SlashEquip\LaravelSegment\Contracts\CanBeIdentifiedForSegment;
 use SlashEquip\LaravelSegment\Contracts\CanBeSentToSegment;
@@ -19,7 +20,16 @@ use SlashEquip\LaravelSegment\PendingUserSegment;
  * @method static PendingUserSegment forUser(CanBeIdentifiedForSegment $user)
  * @method static void push(CanBeSentToSegment $segment)
  * @method static void terminate()
- *
+ * @method static void assertIdentified(Closure|int|null $callback = null)
+ * @method static void assertIdentifiedTimes(int $times)
+ * @method static void assertNotIdentified(Closure $callback = null)
+ * @method static void assertNothingIdentified()
+ * @method static void assertTracked(Closure|int|null $callback = null)
+ * @method static void assertTrackedTimes(int $times)
+ * @method static void assertEventTracked(string $event,Closure|int|null $callback = null)
+ * @method static void assertNotTracked(Closure $callback = null)
+ * @method static void assertNothingTracked()
+
  * @see \SlashEquip\LaravelSegment\SegmentService
  * @see SegmentFake
  */

--- a/tests/Unit/SegmentFakeTest.php
+++ b/tests/Unit/SegmentFakeTest.php
@@ -38,6 +38,18 @@ it('can test that an identity was called', function () {
     Segment::assertIdentifiedTimes(1);
 });
 
+it('can test that an identity was called immediately', function () {
+    Segment::fake();
+
+    Segment::forUser($this->user)->identifyNow([
+        'first_name' => 'Lorem',
+        'last_name' => 'Ipsum',
+    ]);
+
+    Segment::assertIdentified();
+    Segment::assertIdentifiedTimes(1);
+});
+
 it('can test that an identity was called one times', function () {
     Segment::fake();
 
@@ -108,6 +120,19 @@ it('can test that an event was tracked', function () {
     Segment::fake();
 
     Segment::forUser($this->user)->track('some_event', [
+        'first_name' => 'Lorem',
+        'last_name' => 'Ipsum',
+    ]);
+
+    Segment::assertTracked();
+    Segment::assertTrackedTimes(1);
+});
+
+
+it('can test that an event was tracked immediately', function () {
+    Segment::fake();
+
+    Segment::forUser($this->user)->trackNow('some_event', [
         'first_name' => 'Lorem',
         'last_name' => 'Ipsum',
     ]);


### PR DESCRIPTION
The `trackNow` and `identifyNow` are not available on the `SegmentFake` so cannot be used when testing.

This adds the missing methods to the Fake.

I have not added any updated logic to test if the identification happened immediately as I think the existing assertion methods should suffice.